### PR TITLE
Fix: Chart 반응형 크기 조정 문제 해결

### DIFF
--- a/src/components/ChartBar.vue
+++ b/src/components/ChartBar.vue
@@ -38,6 +38,7 @@ export default defineComponent({
     const options = ref({
       barThickness: 10,
       responsive: true,
+      maintainAspectRatio: false,
       indexAxis: "y",
       scales: {
         x: {

--- a/src/components/ChartDoughnut.vue
+++ b/src/components/ChartDoughnut.vue
@@ -44,14 +44,6 @@ export default defineComponent({
     },
   },
   components: { DoughnutChart },
-  data() {
-    return {
-      chartOptions: {
-        type: Object,
-        default: {},
-      },
-    };
-  },
   setup(props) {
     let matchRate = ref(0);
     let chartData = reactive({
@@ -67,6 +59,10 @@ export default defineComponent({
       ],
     });
 
+    const chartOptions = ref({
+      maintainAspectRatio: false,
+    });
+
     watch(
       () => props.enterpriseResult,
       () => {
@@ -75,7 +71,7 @@ export default defineComponent({
       }
     );
 
-    return { chartData, matchRate };
+    return { chartData, matchRate, chartOptions };
   },
 });
 

--- a/src/components/ChartPentagon.vue
+++ b/src/components/ChartPentagon.vue
@@ -28,6 +28,7 @@ export default defineComponent({
   setup(props) {
     const options = {
       reposive: true,
+      maintainAspectRatio: false,
       plugins: {
         legend: { display: false },
         tooltip: { enabled: false },


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
`maintainAspectRatio: false,` 옵션을 추가하면 상위 요소 사이즈에 맞추어 크기가 자동 조정된다고 합니다.
우선은 모든 차트에 적용시켜두었습니다.
![2022-03-16-95043](https://user-images.githubusercontent.com/50618754/158495598-d6ec065c-b096-4b0f-9966-b54e8f5d89e9.gif)

### 테스트 결과
![2022-03-16-95054](https://user-images.githubusercontent.com/50618754/158495605-d7b57b65-ce5a-44d0-8de5-c7b30d88ce45.gif)
