### PR TITLE
Feat: Pentagon Chart 탭 & 리셋 연동

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@
   <chart-pentagon-vue
     :user-result="userResult"
     :enterprise-result="enterpriseResult"
+    :tab-num="tabNum"
   />
   <tabs-select-vue @click-tab="clickNum" />
   <chart-bar-view-vue

--- a/src/components/ChartPentagon.vue
+++ b/src/components/ChartPentagon.vue
@@ -10,6 +10,9 @@ import { defineComponent, watch, ref } from "vue";
 import { RadarChart } from "vue-chart-3";
 import { Chart, registerables } from "chart.js";
 
+const USER = 0;
+const ENTERPRISE = 1;
+
 Chart.register(...registerables);
 
 export default defineComponent({
@@ -23,6 +26,10 @@ export default defineComponent({
     enterpriseResult: {
       type: Array,
       default: null,
+    },
+    tabNum: {
+      type: Number,
+      required: true,
     },
   },
   setup(props) {
@@ -71,6 +78,42 @@ export default defineComponent({
       }
     );
     return { options, chartData };
+  },
+  methods: {
+    show(idx) {
+      this.chartData.datasets[idx].fill = true;
+      this.chartData.datasets[idx].showLine = true;
+    },
+    hide(idx) {
+      this.chartData.datasets[idx].fill = false;
+      this.chartData.datasets[idx].showLine = false;
+    },
+  },
+  beforeUpdate() {
+    const changeTab = {
+      tab: {
+        0: (enterpriseResult) => {
+          this.chartData.datasets[ENTERPRISE].data = [...enterpriseResult];
+          this.show(USER);
+          this.show(ENTERPRISE);
+        },
+        1: () => {
+          this.show(USER);
+          this.hide(ENTERPRISE);
+        },
+        2: (enterpriseResult) => {
+          this.chartData.datasets[ENTERPRISE].data = [...enterpriseResult];
+          this.hide(USER);
+          this.show(ENTERPRISE);
+        },
+      },
+      change(enterpriseResult, tabNum) {
+        console.log(enterpriseResult, tabNum);
+        if (enterpriseResult) this.tab[tabNum](enterpriseResult);
+        else this.tab[1]();
+      },
+    };
+    changeTab.change(this.enterpriseResult, this.tabNum);
   },
 });
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 펜타곤 차트 탭과 연동
- 펜타곤 차트 리셋 시에도 기업 차트 사라지지 않는 이슈 해결 : 
  enterpriseResult props이 null -> 배열로 변경되었을 때는 변경이 감지되어 렌더링이 일어나는데, 
  배열 -> null로 변경되었을 때 감지가 안되어서 
  일단은 배열 -> null로 변경되는 케이스(리셋)에는 hide 처리를 했습니다. 

### 테스트 결과
https://user-images.githubusercontent.com/52448114/158941141-d4290124-fafc-4272-af61-1e4cc4e40360.mov

### Issue
.

### Comment
발표 시간이 얼마 안 남았고 기능은 정상적으로 동작하기 때문에 셀프머지하겠습니다. 